### PR TITLE
Added API for Author Model by creating serializers.py and api.py

### DIFF
--- a/catalog/api.py
+++ b/catalog/api.py
@@ -1,0 +1,11 @@
+from catalog.models import Author
+from rest_framework import viewsets, permissions
+from .serializers import AuthorSerializer
+
+class AuthorViewSet(viewsets.ModelViewSet):
+    queryset = Author.objects.all()
+    permission_classes = [
+        permissions.AllowAny
+    ]
+    serializer_class = AuthorSerializer
+

--- a/catalog/serializers.py
+++ b/catalog/serializers.py
@@ -1,0 +1,7 @@
+from rest_framework import serializers
+from catalog.models import Author
+
+class AuthorSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Author
+        fields = '__all__'

--- a/catalog/tests/test_api.py
+++ b/catalog/tests/test_api.py
@@ -1,0 +1,173 @@
+from django.http import response
+from django.test import TestCase
+from rest_framework.test import APIClient, APITestCase
+from catalog.models import Author
+import datetime
+
+class AuthorAPIViewTest(APITestCase):
+    '''This class tests the author CRUD api'''
+    def setUp(cls):
+        '''creating 4 authors'''
+        number_of_authors = 2
+        for author in range(number_of_authors):
+            Author.objects.create(
+                first_name=f'firstname {author}',
+                last_name=f'lastname {author}'
+            )
+    
+    def test_read_author_list_response(self):
+        '''Checking to see if th authors api exists at the desired location'''
+        #Note: according to the django REST framework docs, it is considered best practice to use the absolute url of web apis
+        #Also note that if we were to use the url ''http://127.0.0.1:8000/catalog/api/authors' without the forward slash,
+        #it would return status code 301 (moved permanently) and then redirect to the address with the forward slash
+
+        response = self.client.get('http://127.0.0.1:8000/catalog/api/authors/')
+        self.assertEqual(response.status_code,200)
+
+    def test_read_author_api_list_content(self):
+        '''
+            This tests to see if the body of the response is what we expect
+            i.e a json that contains a list of authors with the correct names and ids
+        '''
+        response = self.client.get(
+                                    'http://127.0.0.1:8000/catalog/api/authors/', 
+                                    format='json')
+        response_body = response.json()
+        expected_response = [
+            {
+                "id": 1,
+                "first_name": "firstname 0",
+                "last_name": "lastname 0",
+                "date_of_birth": None,
+                "date_of_death": None,
+            },
+            {
+                "id": 2,
+                "first_name": "firstname 1",
+                "last_name": "lastname 1",
+                "date_of_birth": None,
+                "date_of_death": None,
+            }
+        ]
+
+        self.assertEqual(response_body,expected_response)
+
+    def test_read_author_id_api_response(self):
+        '''Tests to see if the get request to author id 1 returns 200 or not'''
+        response = self.client.get('http://127.0.0.1:8000/catalog/api/authors/1/')
+        self.assertEqual(response.status_code,200)
+
+    def test_read_author_id_body(self):
+        '''Tests the body of the get request to the author with id = 1'''
+        response = self.client.get(
+                                    'http://127.0.0.1:8000/catalog/api/authors/1/',
+                                    format = 'json')
+        response_body = response.json()
+
+        expected_response = {
+                                "id": 1,
+                                "first_name": "firstname 0",
+                                "last_name": "lastname 0",
+                                "date_of_birth": None,
+                                "date_of_death": None,
+                            }
+
+        self.assertEqual(response_body,expected_response)
+
+    def test_create_author_response(self):
+        '''This tests whether or not an author is created'''
+        data = {
+            "first_name": "John",
+            "last_name": "Doe"
+        }
+        response = self.client.post(
+            'http://127.0.0.1:8000/catalog/api/authors/',
+            data,
+            format="json")
+        
+        #Checking status code 201 created
+        self.assertEqual(response.status_code,201)
+
+    def test_create_author_body(self):
+        '''This tests the body of the response when an author is created'''
+        data = {
+            "first_name": "John",
+            "last_name": "Doe"
+        }
+        response = self.client.post(
+            'http://127.0.0.1:8000/catalog/api/authors/',
+            data,
+            format="json")
+        
+        response_body = response.json()
+        expected_response = {
+            "id": 3,
+            "first_name": "John",
+            "last_name": "Doe",
+            "date_of_birth": None,
+            "date_of_death": None,
+        }
+        #Checking status code 201 created
+        self.assertEqual(response_body,expected_response)
+
+    def test_update_author_response(self):
+        '''This tests whether or not an author is updated'''
+        data = {
+            "first_name": "John",
+            "last_name": "Doe"
+        }
+        response = self.client.put(
+            'http://127.0.0.1:8000/catalog/api/authors/1/',
+            data,
+            format="json")
+        
+        #Checking status code 201 created
+        self.assertEqual(response.status_code,200)
+
+    def test_update_author(self):
+        '''This tests whether or not an author is updated in the database'''
+        data = {
+            "first_name": "John",
+            "last_name": "Doe"
+        }
+        #Get the orginal value of the author to be updated
+        author_2 = Author.objects.get(id = 2)
+
+        #Update the chosen author
+        response = self.client.put(
+            'http://127.0.0.1:8000/catalog/api/authors/2/',
+            data,
+            format="json")
+        
+        #Check whether the author is updated in the database
+        self.assertNotEqual(str(author_2),str(Author.objects.get(id = 2)))
+
+    def test_delete_author_response(self):
+        '''This tests whether an author gets deleted'''
+        response = self.client.delete('http://127.0.0.1:8000/catalog/api/authors/2/')
+
+        #204 means that the request completed but no reponse was returned
+        self.assertEqual(response.status_code,204)
+
+    def test_author_was_deleted(self):
+        '''This tests whether or not an author was deleted successfuly in the database'''
+
+        #Count the number of authors before the delete
+        count_before_delete = Author.objects.count()
+        response = self.client.delete('http://127.0.0.1:8000/catalog/api/authors/2/')
+        
+        #Count number of authors after delete
+        count_after_delete = Author.objects.count()
+        self.assertLess(count_after_delete,count_before_delete)
+
+
+
+
+
+
+
+
+
+
+    
+

--- a/catalog/tests/test_views.py
+++ b/catalog/tests/test_views.py
@@ -842,7 +842,7 @@ class BookCreateViewTest(TestCase):
                                                             'language': book_language,
                                                             'genre':book_genre})
 
-        self.assertRedirects(response,reverse('book-detail',kwargs={'pk':1}))
+        self.assertRedirects(response,reverse('book-detail', kwargs={'pk':1}))
 
 
 class BookUpdateViewTest(TestCase):
@@ -960,11 +960,11 @@ class BookUpdateViewTest(TestCase):
         test_genres = response.context['form'].initial['genre']
 
         response_post = self.client.post(reverse('book-update',kwargs={'pk':1}),{'title': 'Lord of The Rings',
-                                                            'author': 'Generic, Name',
-                                                            'summary': "Some summary",
-                                                            'isbn': "ABCD",
-                                                            'language': "Enlish I guess",
-                                                            'genre':['Fiction']})
+                                                                                'author': 'Generic, Name',
+                                                                                'summary': "Some summary",
+                                                                                'isbn': "ABCD",
+                                                                                'language': "Enlish I guess",
+                                                                                'genre':['Fiction']})
         
         self.assertEqual(response_post.status_code,302)
 

--- a/catalog/urls.py
+++ b/catalog/urls.py
@@ -1,5 +1,10 @@
 from django.urls import path
 from . import views
+from rest_framework import routers
+from .api  import AuthorViewSet
+
+router = routers.DefaultRouter()
+router.register('api/authors',AuthorViewSet,'author-api')
 
 urlpatterns = [
     path('', views.index, name='index'),
@@ -17,3 +22,5 @@ urlpatterns = [
     path('book/<int:pk>/update/', views.BookUpdate.as_view(), name='book-update'),
     path('book/<int:pk>/delete/', views.BookDelete.as_view(), name='book-delete'),
 ]
+
+urlpatterns += router.urls

--- a/locallibrary/settings.py
+++ b/locallibrary/settings.py
@@ -42,6 +42,7 @@ INSTALLED_APPS = [
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'catalog.apps.CatalogConfig', #This object was created for us in /catalog/apps.py
+    'rest_framework'
 ]
 
 MIDDLEWARE = [

--- a/locallibrary/urls.py
+++ b/locallibrary/urls.py
@@ -43,3 +43,4 @@ urlpatterns += static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)
 urlpatterns += [
     path('accounts/', include('django.contrib.auth.urls')),
 ]
+


### PR DESCRIPTION
### Current Status
Currently, the entire project works using urls and views, and the django REST framework is not utilized

### Changes/Additions
This PR adds CRUD api for the author model by creating a serializer class which allows us to convert native python types to json or xml. This serializer is then used with a viewset for the author class which has an associated url in the urls.py file. We can thus use this url to send Http requests to the server allowing us to perform CRUD operations.

The url associated with the API is: http://127.0.0.1:8000/catalog/api/authors. We can perform CRUD operations on specific authors by passing the id in the url. i.e http://127.0.0.1:8000/catalog/api/authors/5/ to perform operations on the author with id = 5

GET all authors
![get all](https://user-images.githubusercontent.com/85993939/127282210-7909bdb5-6e5f-4a47-b75b-b911eedbfc7d.JPG)

GET specific author
![get specific author 2](https://user-images.githubusercontent.com/85993939/127282259-89d179b1-5d6c-4d4e-a7db-e327c587b0d2.JPG)

POST author
![Post author](https://user-images.githubusercontent.com/85993939/127282354-de91ca45-6553-4d6d-8f77-b90e0bd861ed.JPG)

the result of the POST request:
![post author results](https://user-images.githubusercontent.com/85993939/127282465-f41c53e1-4ae1-494d-a53c-8476597f2383.JPG)

PUT author
![put specific author](https://user-images.githubusercontent.com/85993939/127282542-d8cefaad-7c23-4ae4-ae50-8f55ea526d86.JPG)

DELETE
![delete author](https://user-images.githubusercontent.com/85993939/127282667-1a223bd7-9fbc-4f68-bf97-d7924fe0fb9d.JPG)

### Feedback
I'd like feedback on whether or not this is the best way to go about implementing REST apis. The serializer and viewset I used in the PR are generic and there are other ways of going about this so I'm not sure If this is the best method. I'd also like feedback on the code in general, style guide, etc