### PR TITLE
Added permissions to allow only librarians to perform create, update, and delete operations

### DIFF
--- a/catalog/api.py
+++ b/catalog/api.py
@@ -1,11 +1,14 @@
 from catalog.models import Author
 from rest_framework import viewsets, permissions
 from .serializers import AuthorSerializer
+from .permissions import IsLibrarian #importing our custom permission
 
 class AuthorViewSet(viewsets.ModelViewSet):
     queryset = Author.objects.all()
+
+    #Adding our own custom permission to the viewset
     permission_classes = [
-        permissions.AllowAny
+        IsLibrarian
     ]
     serializer_class = AuthorSerializer
 

--- a/catalog/permissions.py
+++ b/catalog/permissions.py
@@ -1,0 +1,34 @@
+from rest_framework import permissions
+
+
+#Creating our own custom permission to allow only users in the librarian group to perfrom CRUD operations
+class IsLibrarian(permissions.BasePermission):
+
+    def has_permission(self,request,view):
+        if request.method in permissions.SAFE_METHODS:
+            '''
+            This overides the has_permission method of the BasePermission class.
+            The method first checks if the method request is in SAFE_METHODS attribute of the permissions class
+            The SAFE_METHOD attribute is a tuple of the form ('GET','HEAD','OPTION') that checks
+            if the method of the request is one of the "safe" read operations.
+            basically, if the user is performing a GET, HEAD, or OPTION request then they have the permission to do so
+            '''
+            return True
+        elif request.user.groups.filter(name="Librarians"):
+            '''
+            This checks if the user is part of the librarians group which we defined earlier in one of the tutorials.
+            Librarians have access to all the possible request to the api
+            '''
+            return True
+        
+        '''
+        Users that are not librarians will only be given permissions if they are performing
+        One of methods in the SAFE_METHODS attributes. So anonymous users and norml non librarians only get access read operations
+        '''
+        return False
+
+
+
+
+
+

--- a/locallibrary/settings.py
+++ b/locallibrary/settings.py
@@ -152,3 +152,14 @@ STATIC_URL = '/static/'
 # Simplified static file serving.
 # https://warehouse.python.org/project/whitenoise/
 STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'
+
+
+#Adding a default, project level permission to the entire project.
+#This permission means that by default, any kind of http method can be used at any time
+REST_FRAMEWORK = {
+    'DEFAULT_PERMISSION_CLASSES': [
+        'rest_framework.permissions.DjangoModelPermissionsOrAnonReadOnly',
+    ]
+}
+
+


### PR DESCRIPTION
### Current Status
Currently the author api can be used by any user regardless of whether they have been authenticated or not

### Changes/Additions
This PR creates a new permissions.py file that allows only users within the librarians group to perform create, update, and delete operations

### GET requests:
GET request from librarian:
![merlinGET](https://user-images.githubusercontent.com/85993939/127875546-3df24acc-b43b-4d2e-a2c0-e5832704e482.JPG)

GET request from anonymous (not signed in user):
![anonGET](https://user-images.githubusercontent.com/85993939/127875628-b2a0497e-81ff-45a6-b9d3-f622348f9c81.JPG)

GET request from a non librarian user:
![ClarkGET](https://user-images.githubusercontent.com/85993939/127875686-77647e85-93b4-418f-9561-0439e2f4a52f.JPG)

### POST requests:
POST Librarian:
![MerlinPut](https://user-images.githubusercontent.com/85993939/127875909-8b58fef7-99e1-46b0-b931-eddc3e896710.JPG)

POST anonymous user:
![anonPOST](https://user-images.githubusercontent.com/85993939/127875976-de79b34e-f1be-4586-b580-350ed5744b71.JPG)

POST non librarian user:
![ClarkPost](https://user-images.githubusercontent.com/85993939/127876061-b2c0cbb4-637d-40da-ab90-42d88398aa92.JPG)

### Feedback
I'd like feedback on whether or not this is the best way to handle the permissions and whether or not the default permission used in the settings.py file is appropriate or not. In this case the built in django groups model was used to classify the user into librarians and normal library users, in order to add people to this group we must use the built in django admin site. I don't know if there could be a better way to distinguish between users who should have write permissions and users who shouldn't.

