### PR TITLE
This refactors the urls.py file to only contain API endpoints that follow REST API best practices

### DIFF
--- a/catalog/app_urls.py
+++ b/catalog/app_urls.py
@@ -1,0 +1,23 @@
+'''
+This file contains urls for the views in the django app.
+The API endpints for the REST API are in the urls.py file
+'''
+from django.urls import path
+from . import views
+
+urlpatterns = [
+    path('', views.index, name='index'),
+    path('books/', views.BookListView.as_view(), name='books'),
+    path('book/<int:pk>', views.BookDetailView.as_view(), name='book-detail'),
+    path('authors/', views.AuthorListView.as_view(), name='authors'),
+    path('author/<int:pk>', views.AuthorDetailView.as_view(), name='author-detail'),
+    path('mybooks/', views.LoanedBooksByUserListView.as_view(), name='my-borrowed'),
+    path('borrowed/', views.BorrowedBooksListView.as_view(), name='borrowed'),
+    path('book/<uuid:pk>/renew/', views.renew_book_librarian, name='renew-book-librarian'),
+    path('author/create/', views.AuthorCreate.as_view(), name='author-create'),
+    path('author/<int:pk>/update/', views.AuthorUpdate.as_view(), name='author-update'),
+    path('author/<int:pk>/delete/', views.AuthorDelete.as_view(), name='author-delete'),
+    path('book/create/', views.BookCreate.as_view(), name='book-create'),
+    path('book/<int:pk>/update/', views.BookUpdate.as_view(), name='book-update'),
+    path('book/<int:pk>/delete/', views.BookDelete.as_view(), name='book-delete'),
+]

--- a/catalog/urls.py
+++ b/catalog/urls.py
@@ -11,20 +11,6 @@ router.register('api/authors',AuthorViewSet,'author-api')
 router.register('api/books',BookViewSet,'book-api')
 
 urlpatterns = [
-    path('', views.index, name='index'),
-    path('books/', views.BookListView.as_view(), name='books'),
-    path('book/<int:pk>', views.BookDetailView.as_view(), name='book-detail'),
-    path('authors/', views.AuthorListView.as_view(), name='authors'),
-    path('author/<int:pk>', views.AuthorDetailView.as_view(), name='author-detail'),
-    path('mybooks/', views.LoanedBooksByUserListView.as_view(), name='my-borrowed'),
-    path('borrowed/', views.BorrowedBooksListView.as_view(), name='borrowed'),
-    path('book/<uuid:pk>/renew/', views.renew_book_librarian, name='renew-book-librarian'),
-    path('author/create/', views.AuthorCreate.as_view(), name='author-create'),
-    path('author/<int:pk>/update/', views.AuthorUpdate.as_view(), name='author-update'),
-    path('author/<int:pk>/delete/', views.AuthorDelete.as_view(), name='author-delete'),
-    path('book/create/', views.BookCreate.as_view(), name='book-create'),
-    path('book/<int:pk>/update/', views.BookUpdate.as_view(), name='book-update'),
-    path('book/<int:pk>/delete/', views.BookDelete.as_view(), name='book-delete'),
     path('api/token/', custom_tokens.AddIsLibrarianClaimView.as_view(), name='token_obtain_pair'),#Views needed to use the simplejwt package
     path('api/token/refresh/', TokenRefreshView.as_view(), name='token_refresh'),#View needed to create a new access token once the current one expires
     path('api/register',RegisterApiView.as_view(), name='user-register-api'),#View needed to create

--- a/locallibrary/urls.py
+++ b/locallibrary/urls.py
@@ -31,6 +31,10 @@ urlpatterns = [
 ]
 
 urlpatterns += [
+    path('catalog/', include('catalog.app_urls')),
+]
+
+urlpatterns += [
     path('catalog/', include('catalog.urls')),
 ]
 


### PR DESCRIPTION
### Current Status
Currently the urls.py file contains both the API endpoints and the urls for the views in the django app.

### Changes/Additions
The urls.py file was refactors so that now it only contains the api endpoints, the django app urls were moved to another file called app_urls.py. 

Currently the API endpoints in the urls.py file seem fine, but in the other PR's they are not made with REST best practices in mind i.e they contain verbs, do not make use of the models when they could etc.

This PR is the first step in fixing these mistakes going forward.

### Feedback
I'd like Feedback on best practices, coding style etc.